### PR TITLE
fix: google vendors id creation

### DIFF
--- a/modules/core/src/GVL.ts
+++ b/modules/core/src/GVL.ts
@@ -203,7 +203,7 @@ export class GVL extends Cloneable<GVL> implements VendorList {
   */
   private googleVendors_: IntMap<GoogleVendor>;
 
-  public googleVendorIds: Set<number>;
+  public googleVendorIds: Set<string>;
 
   /**
   * @param {IntMap<GoogleVendor>} a collection of [[GoogleVendor]]. Used as a backup if a whitelist is sets
@@ -938,7 +938,7 @@ export class GVL extends Cloneable<GVL> implements VendorList {
 
     }, {});
 
-    this.googleVendorIds = new Set(vendorIds);
+    this.googleVendorIds = new Set(Object.keys(this.googleVendors_));
 
   }
 

--- a/modules/core/test/ReportedIssues.test.ts
+++ b/modules/core/test/ReportedIssues.test.ts
@@ -1,6 +1,6 @@
 import * as sinon from 'sinon';
 import {GVL, TCString, TCModel} from '../src';
-import {XMLHttpTestTools, makeRandomInt, GVLFactory} from '@iabtechlabtcf/testing';
+import {XMLHttpTestTools, makeRandomInt, GVLFactory} from '@cookiepal-labs/iabtcf-testing';
 import {expect} from 'chai';
 import {PurposeRestriction} from '../src/model/PurposeRestriction';
 import {RestrictionType} from '../src/model/RestrictionType';


### PR DESCRIPTION
### Description
It fixes an error spotted during the creation of google vendors id (it wasn't using the google vendors object).